### PR TITLE
fix(typography): use correct var() syntax for text weights

### DIFF
--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -265,15 +265,15 @@ h1, h2, h3, h4, h5, h6, p, div, span, section, li {
  */
 
 .text-extra-light {
-  font-weight: --text-weight-extra-light;
+  font-weight: var(--text-weight-extra-light);
 }
 
 .text-light {
-  font-weight: --text-weight-light;
+  font-weight: var(--text-weight-light);
 }
 
 .text-regular {
-  font-weight: --text-weight-regular;
+  font-weight: var(--text-weight-regular);
 }
 
 /*
@@ -285,19 +285,19 @@ h1, h2, h3, h4, h5, h6, p, div, span, section, li {
  * to ensure contrast ratios are still sufficiently high.
  */
 .text-semibold {
-  font-weight: --text-weight-semibold;
+  font-weight: var(--text-weight-semibold);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .text-bold {
-  font-weight: --text-weight-bold;
+  font-weight: var(--text-weight-bold);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
 .text-black {
-  font-weight: --text-weight-black;
+  font-weight: var(--text-weight-black);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
When using CSS properties, it helps to actually use them rather than writing something else you think will work.